### PR TITLE
Unify constants

### DIFF
--- a/ramanalysis/calibrate.py
+++ b/ramanalysis/calibrate.py
@@ -35,6 +35,10 @@ NEON_PEAKS_NM: ScalarArray = np.array(
     ]
 )
 ACETONITRILE_PEAKS_CM1: ScalarArray = np.array([918, 1376, 2249, 2942, 2999])
+EXCITATION_WAVELENGTH_NM: float = 532.0
+KERNEL_SIZE: int = 5
+ROUGH_CALIBRATION_RESIDUALS_THRESHOLD = 1e0
+FINE_CALIBRATION_RESIDUALS_THRESHOLD = 1e2
 
 
 class _OpenRamanDataProcessor:
@@ -46,9 +50,9 @@ class _OpenRamanDataProcessor:
         csv_filepath_excitation_calibration: Path | str,
         csv_filepath_emission_calibration: Path | str,
         excitation_wavelength_nm: float,
-        kernel_size: int,
-        rough_calibration_residuals_threshold: float,
-        fine_calibration_residuals_threshold: float,
+        kernel_size: int = KERNEL_SIZE,
+        rough_calibration_residuals_threshold: float = ROUGH_CALIBRATION_RESIDUALS_THRESHOLD,
+        fine_calibration_residuals_threshold: float = FINE_CALIBRATION_RESIDUALS_THRESHOLD,
     ) -> None:
         self.csv_filepath = Path(csv_filepath)
         self.csv_filepath_excitation_calibration = Path(csv_filepath_excitation_calibration)
@@ -98,9 +102,9 @@ class _OpenRamanDataCalibrator:
         csv_filepath_excitation_calibration: Path | str,
         csv_filepath_emission_calibration: Path | str,
         excitation_wavelength_nm: float,
-        kernel_size: int,
-        rough_calibration_residuals_threshold: float,
-        fine_calibration_residuals_threshold: float,
+        kernel_size: int = KERNEL_SIZE,
+        rough_calibration_residuals_threshold: float = ROUGH_CALIBRATION_RESIDUALS_THRESHOLD,
+        fine_calibration_residuals_threshold: float = FINE_CALIBRATION_RESIDUALS_THRESHOLD,
     ) -> None:
         self.csv_filepath_excitation_calibration = Path(csv_filepath_excitation_calibration)
         self.csv_filepath_emission_calibration = Path(csv_filepath_emission_calibration)

--- a/ramanalysis/spectra.py
+++ b/ramanalysis/spectra.py
@@ -6,7 +6,14 @@ from pathlib import Path
 from natsort import natsorted
 from scipy.signal import find_peaks, medfilt
 
-from .calibrate import _OpenRamanDataCalibrator, _OpenRamanDataProcessor
+from .calibrate import (
+    EXCITATION_WAVELENGTH_NM,
+    FINE_CALIBRATION_RESIDUALS_THRESHOLD,
+    KERNEL_SIZE,
+    ROUGH_CALIBRATION_RESIDUALS_THRESHOLD,
+    _OpenRamanDataCalibrator,
+    _OpenRamanDataProcessor,
+)
 from .peak_fitting import find_n_most_prominent_peaks
 from .readers import (
     read_horiba_txt,
@@ -30,10 +37,10 @@ class RamanSpectrum:
         csv_filepath: Path | str,
         csv_filepath_excitation_calibration: Path | str,
         csv_filepath_emission_calibration: Path | str,
-        excitation_wavelength_nm: float = 532,
-        kernel_size: int = 5,
-        rough_calibration_residuals_threshold: float = 1.0,
-        fine_calibration_residuals_threshold: float = 1e2,
+        excitation_wavelength_nm: float = EXCITATION_WAVELENGTH_NM,
+        kernel_size: int = KERNEL_SIZE,
+        rough_calibration_residuals_threshold: float = ROUGH_CALIBRATION_RESIDUALS_THRESHOLD,
+        fine_calibration_residuals_threshold: float = FINE_CALIBRATION_RESIDUALS_THRESHOLD,
     ) -> RamanSpectrum:
         """Load the calibrated Raman spectrum from a CSV file output by the OpenRAMAN spectrometer.
 
@@ -144,10 +151,10 @@ class RamanSpectra:
         sample_glob_str: str = "*.csv",
         excitation_glob_str: str = "*neon*.csv",
         emission_glob_str: str = "*aceto*.csv",
-        excitation_wavelength_nm: float = 532,
-        kernel_size: int = 5,
-        rough_calibration_residuals_threshold: float = 1.0,
-        fine_calibration_residuals_threshold: float = 1e2,
+        excitation_wavelength_nm: float = EXCITATION_WAVELENGTH_NM,
+        kernel_size: int = KERNEL_SIZE,
+        rough_calibration_residuals_threshold: float = ROUGH_CALIBRATION_RESIDUALS_THRESHOLD,
+        fine_calibration_residuals_threshold: float = FINE_CALIBRATION_RESIDUALS_THRESHOLD,
     ) -> RamanSpectra:
         """Load spectra from a directory of OpenRAMAN data.
 

--- a/ramanalysis/tests/test_calibrate.py
+++ b/ramanalysis/tests/test_calibrate.py
@@ -3,18 +3,17 @@ import pytest
 
 from ramanalysis.calibrate import (
     ACETONITRILE_PEAKS_CM1,
+    EXCITATION_WAVELENGTH_NM,
+    FINE_CALIBRATION_RESIDUALS_THRESHOLD,
+    KERNEL_SIZE,
+    ROUGH_CALIBRATION_RESIDUALS_THRESHOLD,
     _OpenRamanDataCalibrator,
     calculate_raman_shift,
 )
 from ramanalysis.peak_fitting import find_n_most_prominent_peaks
 
-# set tolerances for testing
-ROUGH_CALIBRATION_RESIDUALS_THRESHOLD = 1
-FINE_CALIBRATION_RESIDUALS_THRESHOLD = 100
+# set tolerance for testing
 FINE_CALIBRATION_TOLERANCE_CM1 = 4
-# set parameters for calibration
-EXCITATION_WAVELENGTH_NM = 532
-KERNEL_SIZE = 5
 
 
 def test_calculate_raman_shift_basic():


### PR DESCRIPTION
Parameters such as `kernel_size`, and thresholds for the rough and fine calibration thresholds were defined in multiple modules. This PR fixes that by defining them in the calibrate module and importing them in every other module including for testing.