### PR TITLE
Update spectra.py

### DIFF
--- a/ramanalysis/spectra.py
+++ b/ramanalysis/spectra.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import cast
 
 import numpy as np
+import pandas as pd
 from scipy.signal import find_peaks, medfilt
 
 from .calibrate import (
@@ -137,6 +138,18 @@ class RamanSpectrum:
         """Load a Raman spectrum from a CSV file output by the Wasatch WP 785X."""
         wavenumbers_cm1, intensities, _metadata = read_wasatch_csv(csv_filepath)
         return RamanSpectrum(wavenumbers_cm1, intensities)
+
+    @classmethod
+    def from_generic_csvfile(
+        cls,
+        csv_filepath: Path | str,
+        wavenumber_cm1_index: int = 0,
+        intensity_index: int = 1,
+        **kwargs,
+    ) -> RamanSpectrum:
+        """"""
+        data = pd.read_csv(csv_filepath, **kwargs).values  # type: ignore
+        return RamanSpectrum(wavenumbers_cm1=data[:, 0], intensities=data[:, 1])
 
     @property
     def snr(self) -> float:

--- a/ramanalysis/spectra.py
+++ b/ramanalysis/spectra.py
@@ -147,9 +147,21 @@ class RamanSpectrum:
         intensity_index: int = 1,
         **kwargs,
     ) -> RamanSpectrum:
-        """"""
+        """Load a Raman spectrum from a CSV file for which there is no pre-defined reader.
+
+        Most data files from Raman spectrometer manufacturers follow a convention where the first
+        column contains the wavenumbers and the second column contains the intensities. Where
+        they vary is in e.g. the delimiter character, the number of rows of metadata, etc. This
+        function assumes this generic format and creates a spectrum object from the data by passing
+        keyword arguments to :func:`pd.read_csv` to support a range of possible formats.
+
+        See also:
+            - https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+        """
         data = pd.read_csv(csv_filepath, **kwargs).values  # type: ignore
-        return RamanSpectrum(wavenumbers_cm1=data[:, 0], intensities=data[:, 1])
+        wavenumbers_cm1 = data[:, wavenumber_cm1_index]
+        intensities = data[:, intensity_index]
+        return RamanSpectrum(wavenumbers_cm1, intensities)
 
     @property
     def snr(self) -> float:


### PR DESCRIPTION
This PR adds a class method for a "generic" reader that assumes the convention that many vendors abide by in which the first column of a CSV file is the wavenumber data and the second column is the intensity data.

The motivation for this is more or less because it's cumbersome to keep adding custom readers for spectrometers when the vast majority of them are structured very similarly and could easily be read with `pandas.read_csv(filename, **kwargs)`.